### PR TITLE
Add sidekiq queue priority

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -2,5 +2,6 @@ class Asset < ApplicationRecord
   validates :symbol, presence: true, uniqueness: true
 
   has_many :quotes
+  has_many :wallet_items
   has_one :last_quote, -> { where(quotes: { current: true }) }, class_name: 'Quote'
 end

--- a/app/services/assets_quotes_service.rb
+++ b/app/services/assets_quotes_service.rb
@@ -1,7 +1,8 @@
 class AssetsQuotesService
   def update_assets_quotes
     Asset.all.each do |asset|
-      SharePriceJob.perform_async(asset.symbol)
+      queue_type = asset.wallet_items.present? ? :critical : :default
+      SharePriceJob.set(queue: queue_type).perform_async(asset.symbol)
     end
   end
 end

--- a/config/initializers/sidekiq.yml
+++ b/config/initializers/sidekiq.yml
@@ -1,0 +1,9 @@
+:concurrency: 5
+staging:
+  :concurrency: 10
+production:
+  :concurrency: 10
+:queues:
+  - critical
+  - default
+  - low

--- a/spec/services/assets_quotes_service_spec.rb
+++ b/spec/services/assets_quotes_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AssetsQuotesService, type: :service do
     end
 
     context "when don't have asset on wallet" do
-      it 'watch list asset has queue critical' do
+      it 'watch list asset has queue default' do
         expect(SharePriceJob).to receive(:set).with({queue: :default}).and_call_original
         AssetsQuotesService.new.update_assets_quotes
         expect(SharePriceJob).to have_enqueued_sidekiq_job(petr4.symbol)

--- a/spec/services/assets_quotes_service_spec.rb
+++ b/spec/services/assets_quotes_service_spec.rb
@@ -1,10 +1,30 @@
 require 'rails_helper'
+require 'sidekiq/testing'
+
 RSpec.describe AssetsQuotesService, type: :service do
+  Sidekiq::Testing.fake!
+  
+  let!(:user) { User.create!(email: 'test@test.com', password: '123456')}
+  let(:wallet) { Wallet.create!(user: user) }
+  let!(:petr4) { Asset.create!(symbol: 'PETR4', currency: 'BRL') }
+
   describe '#update_assets_quotes' do
-    it 'calls' do
-      assets = AssetsQuotesService.new
-      allow(AssetsQuotesService.new).to receive(:update_assets_quotes).and_return([])
-      expect(assets.update_assets_quotes).to eq([])
+    context "when have asset on wallet" do
+      let!(:watch_list) { WalletItem.create!(wallet: wallet, asset: petr4) }
+      
+      it 'watch list asset has queue critical' do
+        expect(SharePriceJob).to receive(:set).with({queue: :critical}).and_call_original
+        AssetsQuotesService.new.update_assets_quotes
+        expect(SharePriceJob).to have_enqueued_sidekiq_job(petr4.symbol)
+      end
+    end
+
+    context "when don't have asset on wallet" do
+      it 'watch list asset has queue critical' do
+        expect(SharePriceJob).to receive(:set).with({queue: :default}).and_call_original
+        AssetsQuotesService.new.update_assets_quotes
+        expect(SharePriceJob).to have_enqueued_sidekiq_job(petr4.symbol)
+      end
     end
   end
 end


### PR DESCRIPTION
#### Tarefa 3 - Priorizar ativos que estão nas watchlist
* Os ativos que estão nas watchlists de usuários sempre devem ser processadas primeiro dos que não estão, ou seja, quando houver uma fila de cotações sendo processadas, os ativos que estão nas watchlists devem ser os primeiros dessa fila;